### PR TITLE
Add rig and maze to metadata

### DIFF
--- a/spec/ndx-tank-metadata.extensions.yaml
+++ b/spec/ndx-tank-metadata.extensions.yaml
@@ -24,3 +24,90 @@ groups:
   - name: session_performance
     dtype: float
     doc: Performance of correct responses in %
+    required: false
+  groups:
+  - name: rig
+    neurodata_type_inc: RigExtension
+    doc: type for storing rig information
+  - name: mazes
+    neurodata_type_inc: MazeExtension
+    doc: type for storing maze information
+- neurodata_type_def: RigExtension
+  neurodata_type_inc: LabMetaData
+  doc: type for storing rig information
+  attributes:
+  - name: rig
+    dtype: text
+    doc: rig information
+  - name: simulationMode
+    dtype: text
+    doc: rig information
+  - name: hasDAQ
+    dtype: text
+    doc: rig information
+  - name: hasSyncComm
+    dtype: text
+    doc: rig information
+  - name: minIterationDT
+    dtype: text
+    doc: rig information
+  - name: arduinoPort
+    dtype: text
+    doc: rig information
+  - name: sensorDotsPerRev
+    dtype: text
+    doc: rig information
+  - name: ballCircumference
+    dtype: text
+    doc: rig information
+  - name: toroidXFormP1
+    dtype: text
+    doc: rig information
+  - name: toroidXFormP2
+    dtype: text
+    doc: rig information
+  - name: colorAdjustment
+    dtype: text
+    doc: rig information
+  - name: soundAdjustment
+    dtype: text
+    doc: rig information
+  - name: nidaqDevice
+    dtype: text
+    doc: rig information
+  - name: nidaqPort
+    dtype: text
+    doc: rig information
+  - name: nidaqLines
+    dtype: text
+    doc: rig information
+  - name: syncClockChannel
+    dtype: text
+    doc: rig information
+  - name: syncDataChannel
+    dtype: text
+    doc: rig information
+  - name: rewardChannel
+    dtype: text
+    doc: rig information
+  - name: rewardSize
+    dtype: text
+    doc: rig information
+  - name: rewardDuration
+    dtype: text
+    doc: rig information
+  - name: laserChannel
+    dtype: text
+    doc: rig information
+  - name: rightPuffChannel
+    dtype: text
+    doc: rig information
+  - name: leftPuffChannel
+    dtype: text
+    doc: rig information
+  - name: webcam_name
+    dtype: text
+    doc: rig information
+- neurodata_type_def: MazeExtension
+  neurodata_type_inc: DynamicTable
+  doc: type for storing maze information

--- a/spec/ndx-tank-metadata.extensions.yaml
+++ b/spec/ndx-tank-metadata.extensions.yaml
@@ -25,6 +25,12 @@ groups:
     dtype: float
     doc: Performance of correct responses in %
     required: false
+  - name: session_end_time
+    dtype: text
+    doc: Datetime when session ended
+  - name: num_trials
+    dtype: int
+    doc: Number of trials during the session
   groups:
   - name: rig
     neurodata_type_inc: RigExtension
@@ -40,70 +46,76 @@ groups:
     dtype: text
     doc: rig information
   - name: simulationMode
-    dtype: text
+    dtype: int
     doc: rig information
   - name: hasDAQ
-    dtype: text
+    dtype: int
     doc: rig information
   - name: hasSyncComm
-    dtype: text
+    dtype: int
     doc: rig information
   - name: minIterationDT
-    dtype: text
+    dtype: float
     doc: rig information
   - name: arduinoPort
     dtype: text
     doc: rig information
   - name: sensorDotsPerRev
-    dtype: text
+    dtype: float
+    shape:
+    - null
     doc: rig information
   - name: ballCircumference
-    dtype: text
+    dtype: float
     doc: rig information
   - name: toroidXFormP1
-    dtype: text
+    dtype: float
     doc: rig information
   - name: toroidXFormP2
-    dtype: text
+    dtype: float
     doc: rig information
   - name: colorAdjustment
-    dtype: text
+    dtype: float
+    shape:
+    - null
     doc: rig information
   - name: soundAdjustment
-    dtype: text
+    dtype: float
     doc: rig information
   - name: nidaqDevice
-    dtype: text
+    dtype: int
     doc: rig information
   - name: nidaqPort
-    dtype: text
+    dtype: int
     doc: rig information
   - name: nidaqLines
-    dtype: text
+    dtype: int
+    shape:
+    - null
     doc: rig information
   - name: syncClockChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: syncDataChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rewardChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rewardSize
-    dtype: text
+    dtype: float
     doc: rig information
   - name: rewardDuration
-    dtype: text
+    dtype: float
     doc: rig information
   - name: laserChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rightPuffChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: leftPuffChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: webcam_name
     dtype: text

--- a/spec/ndx-tank-metadata.namespace.yaml
+++ b/spec/ndx-tank-metadata.namespace.yaml
@@ -11,5 +11,6 @@ namespaces:
   - namespace: core
     neurodata_types:
     - LabMetaData
+    - DynamicTable
   - source: ndx-tank-metadata.extensions.yaml
   version: 0.1.0

--- a/src/pynwb/ndx_tank_metadata/__init__.py
+++ b/src/pynwb/ndx_tank_metadata/__init__.py
@@ -1,12 +1,5 @@
-import os
-from pynwb import load_namespaces, get_class
+from pynwb import get_class
+from .maze_extension import MazeExtension
 
-
-name = 'ndx-tank-metadata'
-
-spec_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-ns_path = os.path.join(spec_path, 'spec', f'{name}.namespace.yaml')
-
-load_namespaces(ns_path)
-
-LabMetaDataExtension = get_class('LabMetaDataExtension', name)
+LabMetaDataExtension = get_class('LabMetaDataExtension', 'ndx-tank-metadata')
+RigExtension = get_class('RigExtension', 'ndx-tank-metadata')

--- a/src/pynwb/ndx_tank_metadata/maze_extension.py
+++ b/src/pynwb/ndx_tank_metadata/maze_extension.py
@@ -24,7 +24,7 @@ class MazeExtension(DynamicTable):
                   'blockPerform']
 
     __columns__ = tuple(
-        {'name': attr, 'description': 'maze information', 'required': True, 'index': True,
+        {'name': attr, 'description': 'maze information', 'required': True, 'index': False,
          'table': False} for attr in mazes_attr
     )
 

--- a/src/pynwb/ndx_tank_metadata/maze_extension.py
+++ b/src/pynwb/ndx_tank_metadata/maze_extension.py
@@ -1,0 +1,35 @@
+import os
+from pynwb import load_namespaces, register_class
+from pynwb.file import DynamicTable
+from hdmf.utils import docval, call_docval_func, get_docval
+
+name = 'ndx-tank-metadata'
+
+spec_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+ns_path = os.path.join(spec_path, 'spec', f'{name}.namespace.yaml')
+
+load_namespaces(ns_path)
+
+@register_class('MazeExtension', name)
+class MazeExtension(DynamicTable):
+    """
+    Table for storing maze information
+    """
+
+    mazes_attr = ['world', 'lStart', 'lCue', 'lMemory', 'cueDuration', 'cueVisibleAt',
+                  'cueProbability', 'cueDensityPerM', 'antiFraction', 'nCueSlots', 'tri_turnHint',
+                  'color', 'numTrials', 'numTrialsPerMin', 'criteriaNTrials', 'warmupNTrials',
+                  'numSessions', 'performance', 'maxBias', 'warmupMaze', 'warmupPerform',
+                  'warmupBias', 'warmupMotor', 'easyBlock', 'easyBlockNTrials', 'numBlockTrials',
+                  'blockPerform']
+
+    __columns__ = tuple(
+        {'name': attr, 'description': 'maze information', 'required': True, 'index': True,
+         'table': False} for attr in mazes_attr
+    )
+
+    @docval(dict(name='name', type=str, doc='name of this MazeExtension'),  # required
+            dict(name='description', type=str, doc='Description of this DynamicTable'),
+            *get_docval(DynamicTable.__init__, 'id', 'columns', 'colnames'))
+    def __init__(self, **kwargs):
+        call_docval_func(super(MazeExtension, self).__init__, kwargs)

--- a/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.extensions.yaml
+++ b/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.extensions.yaml
@@ -24,3 +24,90 @@ groups:
   - name: session_performance
     dtype: float
     doc: Performance of correct responses in %
+    required: false
+  groups:
+  - name: rig
+    neurodata_type_inc: RigExtension
+    doc: type for storing rig information
+  - name: mazes
+    neurodata_type_inc: MazeExtension
+    doc: type for storing maze information
+- neurodata_type_def: RigExtension
+  neurodata_type_inc: LabMetaData
+  doc: type for storing rig information
+  attributes:
+  - name: rig
+    dtype: text
+    doc: rig information
+  - name: simulationMode
+    dtype: text
+    doc: rig information
+  - name: hasDAQ
+    dtype: text
+    doc: rig information
+  - name: hasSyncComm
+    dtype: text
+    doc: rig information
+  - name: minIterationDT
+    dtype: text
+    doc: rig information
+  - name: arduinoPort
+    dtype: text
+    doc: rig information
+  - name: sensorDotsPerRev
+    dtype: text
+    doc: rig information
+  - name: ballCircumference
+    dtype: text
+    doc: rig information
+  - name: toroidXFormP1
+    dtype: text
+    doc: rig information
+  - name: toroidXFormP2
+    dtype: text
+    doc: rig information
+  - name: colorAdjustment
+    dtype: text
+    doc: rig information
+  - name: soundAdjustment
+    dtype: text
+    doc: rig information
+  - name: nidaqDevice
+    dtype: text
+    doc: rig information
+  - name: nidaqPort
+    dtype: text
+    doc: rig information
+  - name: nidaqLines
+    dtype: text
+    doc: rig information
+  - name: syncClockChannel
+    dtype: text
+    doc: rig information
+  - name: syncDataChannel
+    dtype: text
+    doc: rig information
+  - name: rewardChannel
+    dtype: text
+    doc: rig information
+  - name: rewardSize
+    dtype: text
+    doc: rig information
+  - name: rewardDuration
+    dtype: text
+    doc: rig information
+  - name: laserChannel
+    dtype: text
+    doc: rig information
+  - name: rightPuffChannel
+    dtype: text
+    doc: rig information
+  - name: leftPuffChannel
+    dtype: text
+    doc: rig information
+  - name: webcam_name
+    dtype: text
+    doc: rig information
+- neurodata_type_def: MazeExtension
+  neurodata_type_inc: DynamicTable
+  doc: type for storing maze information

--- a/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.extensions.yaml
+++ b/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.extensions.yaml
@@ -25,6 +25,12 @@ groups:
     dtype: float
     doc: Performance of correct responses in %
     required: false
+  - name: session_end_time
+    dtype: text
+    doc: Datetime when session ended
+  - name: num_trials
+    dtype: int
+    doc: Number of trials during the session
   groups:
   - name: rig
     neurodata_type_inc: RigExtension
@@ -40,70 +46,76 @@ groups:
     dtype: text
     doc: rig information
   - name: simulationMode
-    dtype: text
+    dtype: int
     doc: rig information
   - name: hasDAQ
-    dtype: text
+    dtype: int
     doc: rig information
   - name: hasSyncComm
-    dtype: text
+    dtype: int
     doc: rig information
   - name: minIterationDT
-    dtype: text
+    dtype: float
     doc: rig information
   - name: arduinoPort
     dtype: text
     doc: rig information
   - name: sensorDotsPerRev
-    dtype: text
+    dtype: float
+    shape:
+    - null
     doc: rig information
   - name: ballCircumference
-    dtype: text
+    dtype: float
     doc: rig information
   - name: toroidXFormP1
-    dtype: text
+    dtype: float
     doc: rig information
   - name: toroidXFormP2
-    dtype: text
+    dtype: float
     doc: rig information
   - name: colorAdjustment
-    dtype: text
+    dtype: float
+    shape:
+    - null
     doc: rig information
   - name: soundAdjustment
-    dtype: text
+    dtype: float
     doc: rig information
   - name: nidaqDevice
-    dtype: text
+    dtype: int
     doc: rig information
   - name: nidaqPort
-    dtype: text
+    dtype: int
     doc: rig information
   - name: nidaqLines
-    dtype: text
+    dtype: int
+    shape:
+    - null
     doc: rig information
   - name: syncClockChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: syncDataChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rewardChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rewardSize
-    dtype: text
+    dtype: float
     doc: rig information
   - name: rewardDuration
-    dtype: text
+    dtype: float
     doc: rig information
   - name: laserChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: rightPuffChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: leftPuffChannel
-    dtype: text
+    dtype: int
     doc: rig information
   - name: webcam_name
     dtype: text

--- a/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.namespace.yaml
+++ b/src/pynwb/ndx_tank_metadata/spec/ndx-tank-metadata.namespace.yaml
@@ -11,5 +11,6 @@ namespaces:
   - namespace: core
     neurodata_types:
     - LabMetaData
+    - DynamicTable
   - source: ndx-tank-metadata.extensions.yaml
   version: 0.1.0

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -60,6 +60,7 @@ def main():
         name='session_performance',
         doc='Performance of correct responses in %',
         dtype='float',
+        required=False
     )
 
     RigExtension = NWBGroupSpec(

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -61,9 +61,34 @@ def main():
         dtype='float',
     )
 
+    RigExtension = NWBGroupSpec(
+        doc='type for storing rig information',
+        neurodata_type_def='RigExtension',
+        neurodata_type_inc='LabMetaData',
+    )
+
+    rig_attr = ['rig', 'simulationMode', 'hasDAQ', 'hasSyncComm', 'minIterationDT', 'arduinoPort',
+                'sensorDotsPerRev', 'ballCircumference', 'toroidXFormP1', 'toroidXFormP2',
+                'colorAdjustment', 'soundAdjustment', 'nidaqDevice', 'nidaqPort', 'nidaqLines',
+                'syncClockChannel', 'syncDataChannel', 'rewardChannel', 'rewardSize',
+                'rewardDuration', 'laserChannel', 'rightPuffChannel', 'leftPuffChannel',
+                'webcam_name']
+    for attr in rig_attr:
+        RigExtension.add_attribute(
+            name=attr,
+            doc='rig information',
+            dtype='text',
+        )
+
+    LabMetaDataExtension.add_group(
+        name='rig',
+        neurodata_type_inc='RigExtension',
+        doc='type for storing rig information',
+    )
+
     # export the extension to yaml files in the spec folder
     output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'spec'))
-    export_spec(ns_builder, [LabMetaDataExtension], output_dir)
+    export_spec(ns_builder, [LabMetaDataExtension, RigExtension], output_dir)
 
 
 if __name__ == "__main__":

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -12,6 +12,7 @@ def main():
     )
 
     ns_builder.include_type('LabMetaData', namespace='core')
+    ns_builder.include_type('DynamicTable', namespace='core')
 
     LabMetaDataExtension = NWBGroupSpec(
         doc='type for storing metadata for Tank lab',
@@ -86,9 +87,21 @@ def main():
         doc='type for storing rig information',
     )
 
+    MazeExtension = NWBGroupSpec(
+        doc='type for storing maze information',
+        neurodata_type_def='MazeExtension',
+        neurodata_type_inc='DynamicTable',
+    )
+
+    LabMetaDataExtension.add_group(
+        name='mazes',
+        neurodata_type_inc='MazeExtension',
+        doc='type for storing maze information',
+    )
+
     # export the extension to yaml files in the spec folder
     output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'spec'))
-    export_spec(ns_builder, [LabMetaDataExtension, RigExtension], output_dir)
+    export_spec(ns_builder, [LabMetaDataExtension, RigExtension, MazeExtension], output_dir)
 
 
 if __name__ == "__main__":

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -63,6 +63,18 @@ def main():
         required=False
     )
 
+    LabMetaDataExtension.add_attribute(
+        name='session_end_time',
+        doc='Datetime when session ended',
+        dtype='text',  # temporary solution until datetime is fixed
+    )
+
+    LabMetaDataExtension.add_attribute(
+        name='num_trials',
+        doc='Number of trials during the session',
+        dtype='int',
+    )
+
     RigExtension = NWBGroupSpec(
         doc='type for storing rig information',
         neurodata_type_def='RigExtension',

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -81,18 +81,30 @@ def main():
         neurodata_type_inc='LabMetaData',
     )
 
-    rig_attr = ['rig', 'simulationMode', 'hasDAQ', 'hasSyncComm', 'minIterationDT', 'arduinoPort',
-                'sensorDotsPerRev', 'ballCircumference', 'toroidXFormP1', 'toroidXFormP2',
-                'colorAdjustment', 'soundAdjustment', 'nidaqDevice', 'nidaqPort', 'nidaqLines',
-                'syncClockChannel', 'syncDataChannel', 'rewardChannel', 'rewardSize',
-                'rewardDuration', 'laserChannel', 'rightPuffChannel', 'leftPuffChannel',
-                'webcam_name']
+    rig_attr = [('rig', 'text'), ('simulationMode', 'int'), ('hasDAQ', 'int'),
+                ('hasSyncComm', 'int'), ('minIterationDT', 'float'), ('arduinoPort', 'text'),
+                ('sensorDotsPerRev', 'float'), ('ballCircumference', 'float'),
+                ('toroidXFormP1', 'float'), ('toroidXFormP2', 'float'),
+                ('colorAdjustment', 'float'), ('soundAdjustment', 'float'),
+                ('nidaqDevice', 'int'), ('nidaqPort', 'int'), ('nidaqLines', 'int'),
+                ('syncClockChannel', 'int'), ('syncDataChannel', 'int'),
+                ('rewardChannel', 'int'), ('rewardSize', 'float'),
+                ('rewardDuration', 'float'), ('laserChannel', 'int'),
+                ('rightPuffChannel', 'int'), ('leftPuffChannel', 'int'), ('webcam_name', 'text')]
     for attr in rig_attr:
-        RigExtension.add_attribute(
-            name=attr,
-            doc='rig information',
-            dtype='text',
-        )
+        if attr[0] in ['sensorDotsPerRev', 'colorAdjustment', 'nidaqLines']:
+            RigExtension.add_attribute(
+                name=attr[0],
+                doc='rig information',
+                dtype=attr[1],
+                shape=(None,)
+            )
+        else:
+            RigExtension.add_attribute(
+                name=attr[0],
+                doc='rig information',
+                dtype=attr[1],
+            )
 
     LabMetaDataExtension.add_group(
         name='rig',

--- a/tests/test_ndx_tank_metadata.py
+++ b/tests/test_ndx_tank_metadata.py
@@ -3,7 +3,7 @@ from pynwb import NWBFile, NWBHDF5IO
 import unittest
 from datetime import datetime
 
-from src.pynwb.ndx_tank_metadata import LabMetaDataExtension
+from src.pynwb.ndx_tank_metadata import LabMetaDataExtension, RigExtension, MazeExtension
 
 
 class LabMetaDataExtensionTest(unittest.TestCase):
@@ -12,6 +12,40 @@ class LabMetaDataExtensionTest(unittest.TestCase):
         self.nwbfile = NWBFile('description', 'id', datetime.now().astimezone())
 
     def test_add_lab_metadata(self):
+        # Add rig information
+        rig = {'name': 'rig',
+               'rig': 'VRTrain6',
+               'simulationMode': '0',
+               'hasDAQ': '1',
+               'hasSyncComm': '0',
+               'minIterationDT': '0.01',
+               'arduinoPort': 'COM5',
+               'sensorDotsPerRev': str([1967.6, 1967.6, 1967.6, 1967.6]),
+               'ballCircumference': '63.8',
+               'toroidXFormP1': '0.5193',
+               'toroidXFormP2': '0.5171',
+               'colorAdjustment': str([0., 0.4, 0.5]),
+               'soundAdjustment': '0.2',
+               'nidaqDevice': '1',
+               'nidaqPort': '1',
+               'nidaqLines': str([0, 11]),
+               'syncClockChannel': '5',
+               'syncDataChannel': '6',
+               'rewardChannel': '0',
+               'rewardSize': '0.004',
+               'rewardDuration': '0.05',
+               'laserChannel': '1',
+               'rightPuffChannel': '2',
+               'leftPuffChannel': '3',
+               'webcam_name': 'Live! Cam Sync HD VF0770'}
+        rig_extension = RigExtension(**rig)
+
+        # Create mazes table
+        maze_extension = MazeExtension(name='mazes',
+                                       description='description of the mazes')
+        mazes_dict = {k: ['test'] for k in maze_extension.colnames}
+        maze_extension.add_row(**mazes_dict, id=0)
+
         # Creates LabMetaData container
 
         lab_metadata_dict = dict(
@@ -22,7 +56,8 @@ class LabMetaDataExtensionTest(unittest.TestCase):
             stimulus_bank_path='test',
             commit_id='test',
             location='test',
-            session_performance=1.,
+            rig=rig_extension,
+            mazes=maze_extension
         )
 
         lab_metadata = LabMetaDataExtension(**lab_metadata_dict)
@@ -38,7 +73,14 @@ class LabMetaDataExtensionTest(unittest.TestCase):
         with NWBHDF5IO(filename, mode='r', load_namespaces=True) as io:
             nwbfile = io.read()
 
-            for k, v in lab_metadata_dict.items():
-                self.assertEqual(v, getattr(nwbfile.lab_meta_data['LabMetaData'], k, None))
+            for metadata_key, metadata_value in lab_metadata_dict.items():
+                if isinstance(metadata_value, RigExtension):
+                    for rig_key, rig_value in rig.items():
+                        self.assertEqual(rig_value, getattr(metadata_value, rig_key, None))
+                elif isinstance(metadata_value, MazeExtension):
+                    for mazes_key, mazes_value in mazes_dict.items():
+                        self.assertEqual(mazes_value, getattr(metadata_value, mazes_key, None).data)
+                else:
+                    self.assertEqual(metadata_value, getattr(nwbfile.lab_meta_data['LabMetaData'], metadata_key, None))
 
         os.remove(filename)

--- a/tests/test_ndx_tank_metadata.py
+++ b/tests/test_ndx_tank_metadata.py
@@ -15,36 +15,36 @@ class LabMetaDataExtensionTest(unittest.TestCase):
         # Add rig information
         rig = {'name': 'rig',
                'rig': 'VRTrain6',
-               'simulationMode': '0',
-               'hasDAQ': '1',
-               'hasSyncComm': '0',
-               'minIterationDT': '0.01',
+               'simulationMode': 0,
+               'hasDAQ': 1,
+               'hasSyncComm': 0,
+               'minIterationDT': 0.01,
                'arduinoPort': 'COM5',
-               'sensorDotsPerRev': str([1967.6, 1967.6, 1967.6, 1967.6]),
-               'ballCircumference': '63.8',
-               'toroidXFormP1': '0.5193',
-               'toroidXFormP2': '0.5171',
-               'colorAdjustment': str([0., 0.4, 0.5]),
-               'soundAdjustment': '0.2',
-               'nidaqDevice': '1',
-               'nidaqPort': '1',
-               'nidaqLines': str([0, 11]),
-               'syncClockChannel': '5',
-               'syncDataChannel': '6',
-               'rewardChannel': '0',
-               'rewardSize': '0.004',
-               'rewardDuration': '0.05',
-               'laserChannel': '1',
-               'rightPuffChannel': '2',
-               'leftPuffChannel': '3',
+               'sensorDotsPerRev': [1967.6, 1967.6, 1967.6, 1967.6],
+               'ballCircumference': 63.8,
+               'toroidXFormP1': 0.5193,
+               'toroidXFormP2': 0.5171,
+               'colorAdjustment': [0., 0.4, 0.5],
+               'soundAdjustment': 0.2,
+               'nidaqDevice': 1,
+               'nidaqPort': 1,
+               'nidaqLines': [0, 11],
+               'syncClockChannel': 5,
+               'syncDataChannel': 6,
+               'rewardChannel': 0,
+               'rewardSize': 0.004,
+               'rewardDuration': 0.05,
+               'laserChannel': 1,
+               'rightPuffChannel': 2,
+               'leftPuffChannel': 3,
                'webcam_name': 'Live! Cam Sync HD VF0770'}
         rig_extension = RigExtension(**rig)
 
         # Create mazes table
         maze_extension = MazeExtension(name='mazes',
                                        description='description of the mazes')
-        mazes_dict = {k: ['test'] for k in maze_extension.colnames}
-        maze_extension.add_row(**mazes_dict, id=0)
+        mazes_dict = {k: 'test' for k in maze_extension.colnames}
+        maze_extension.add_row(**mazes_dict)
 
         # Creates LabMetaData container
 
@@ -56,6 +56,8 @@ class LabMetaDataExtensionTest(unittest.TestCase):
             stimulus_bank_path='test',
             commit_id='test',
             location='test',
+            num_trials=245,
+            session_end_time=datetime.utcnow().isoformat(),
             rig=rig_extension,
             mazes=maze_extension
         )
@@ -79,7 +81,7 @@ class LabMetaDataExtensionTest(unittest.TestCase):
                         self.assertEqual(rig_value, getattr(metadata_value, rig_key, None))
                 elif isinstance(metadata_value, MazeExtension):
                     for mazes_key, mazes_value in mazes_dict.items():
-                        self.assertEqual(mazes_value, getattr(metadata_value, mazes_key, None).data)
+                        assert mazes_value in getattr(metadata_value, mazes_key, None).data
                 else:
                     self.assertEqual(metadata_value, getattr(nwbfile.lab_meta_data['LabMetaData'], metadata_key, None))
 


### PR DESCRIPTION
Extends metadata with rig and maze(s) table, based on the requirements [here](https://docs.google.com/spreadsheets/d/1BqmMxzZiaUyCvnOz2mF3XxCtkzu4xqDlPyQRVRqYLCU/edit#gid=0).
